### PR TITLE
Add basic utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest",
     "preview": "vite preview",
     "clean": "rmdir dist /s /q",
     "uninstall-node-modules": "rmdir node_modules /s /q",
@@ -52,6 +53,7 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "typescript": "^5.2.2",
     "vite": "^5.0.8",
-    "vite-plugin-mkcert": "^1.17.3"
+    "vite-plugin-mkcert": "^1.17.3",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { parseWithInterpretation, getFormattedTimestamp } from '../builtins/utils'
+
+describe('parseWithInterpretation', () => {
+  it('parses integer values', () => {
+    expect(parseWithInterpretation('42', 'integer')).toBe(42)
+  })
+
+  it('parses boolean values', () => {
+    expect(parseWithInterpretation('true', 'boolean')).toBe(true)
+  })
+
+  it('parses string values', () => {
+    expect(parseWithInterpretation(123, 'string')).toBe('123')
+  })
+
+  it('returns raw value for unknown interpretation', () => {
+    expect(parseWithInterpretation('{"a":1}', 'object')).toEqual({ a: 1 })
+  })
+})
+
+describe('getFormattedTimestamp', () => {
+  it('returns timestamp with HH:MM:SS.mmm format', () => {
+    const ts = getFormattedTimestamp()
+    expect(ts).toMatch(/^\d{2}:\d{2}:\d{2}\.\d{3}$/)
+  })
+})


### PR DESCRIPTION
## Summary
- add Vitest unit tests for `parseWithInterpretation` and `getFormattedTimestamp`
- register a `test` script and Vitest dependency

## Testing
- `npm test` *(fails: vitest: not found)*